### PR TITLE
Register meta box only if post types are supported

### DIFF
--- a/inc/admin-ui.php
+++ b/inc/admin-ui.php
@@ -13,12 +13,17 @@ use Byline_Manager\Models\Profile;
  * Register meta boxes used by the plugin.
  */
 function register_meta_boxes() {
-	add_meta_box(
-		'byline-manager-byline-meta-box',
-		__( 'Byline', 'byline-manager' ),
-		__NAMESPACE__ . '\byline_meta_box',
-		Utils::get_supported_post_types()
-	);
+	$supported_post_types = Utils::get_supported_post_types();
+
+	if ( $supported_post_types ) {
+		add_meta_box(
+			'byline-manager-byline-meta-box',
+			__( 'Byline', 'byline-manager' ),
+			__NAMESPACE__ . '\byline_meta_box',
+			$supported_post_types
+		);
+	}
+
 	add_meta_box(
 		'byline-manager-user-link-meta-box',
 		__( 'User Account', 'byline-manager' ),


### PR DESCRIPTION
Passing an empty array has the effect of registering the meta box for the current screen.

It's unlikely that zero post types would be supported in practical use, but for debugging purposes (tearing everything down and then restoring features in search of the problem) it's confusing to still see the meta box.