### PR TITLE
Fill in more post type labels

### DIFF
--- a/inc/data-structures.php
+++ b/inc/data-structures.php
@@ -58,6 +58,12 @@ function register_profile() {
 			'exclude_from_search' => true,
 			'has_archive'         => true,
 			'rewrite'             => [
+				/**
+				 * Filters the rewrite slug of the profile post type.
+				 *
+				 * @param string $slug The rewrite slug. Default is the default
+				 *                     base for the author permalink structure.
+				 */
 				'slug'    => apply_filters( 'byline_manager_rewrite_slug', $wp_rewrite->author_base ),
 				'feeds'   => true,
 				'pages'   => true,


### PR DESCRIPTION
Includes the labels for the featured image meta box and [the post type labels added in WordPress 5.0](https://make.wordpress.org/core/2018/12/05/new-post-type-labels-in-5-0/).