### PR TITLE
Ensure all endpoints have a permissions callback

### DIFF
--- a/inc/rest-api.php
+++ b/inc/rest-api.php
@@ -22,16 +22,18 @@ function register_rest_routes() {
 		REST_NAMESPACE,
 		'/authors',
 		[
-			'methods' => \WP_REST_Server::READABLE,
-			'callback' => __NAMESPACE__ . '\rest_profile_search',
+			'methods'             => \WP_REST_Server::READABLE,
+			'callback'            => __NAMESPACE__ . '\rest_profile_search',
+			'permission_callback' => '__return_true',
 		]
 	);
 	register_rest_route(
 		REST_NAMESPACE,
 		'/users',
 		[
-			'methods' => \WP_REST_Server::READABLE,
-			'callback' => __NAMESPACE__ . '\rest_user_search',
+			'methods'             => \WP_REST_Server::READABLE,
+			'callback'            => __NAMESPACE__ . '\rest_user_search',
+			'permission_callback' => '__return_true',
 		]
 	);
 }


### PR DESCRIPTION
WordPress 5.5 will start triggering `_doing_it_wrong` errors for any REST endpoints that don't set a permission_callback. See: https://make.wordpress.org/core/2020/07/22/rest-api-changes-in-wordpress-5-5/

To avoid these errors, we need to ensure all registered routes in the plugin include a permissions callback when registering the route.