### PR TITLE
Fix build errors

### DIFF
--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -1,0 +1,15 @@
+name: JS Tests
+
+on: pull_request
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Test using Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '16'
+      - run: npm ci
+      - run: npm test

--- a/client/src/utils/transform-hydrate-profiles.spec.js
+++ b/client/src/utils/transform-hydrate-profiles.spec.js
@@ -1,4 +1,4 @@
-import transformHydratedProfiles from './transformHydratedProfiles';
+import transformHydratedProfiles from './transform-hydrate-profiles';
 
 describe('transformHydratedProfiles', () => {
   it(

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "jest": {
     "moduleNameMapper": {
       "\\.(css|scss)$": "<rootDir>/client/src/mocks/styleMock.js"
-    }
+    },
+    "modulePathIgnorePatterns": ["<rootDir>/vendor/"]
   },
   "devDependencies": {
     "autoprefixer": "^8.6.0",


### PR DESCRIPTION
This fixes a JS error in our testing suite that caused builds to fail after #60 was merged. It also includes a new GH action that runs our JS tests on PRs so failures are detected before they are merged.

**Changes:**

* Fix casing for import of transform-hydrate-profiles
* Updates Jest config in the `package.json` to ignore files in the vendor directory