### PR TITLE
Fix composer installation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "phpcs": "phpcs . --runtime-set text_domain byline-manager",
     "phpunit": "phpunit"
   },
-  "type": "project",
+  "type": "wordpress-plugin",
   "config": {
     "allow-plugins": {
       "dealerdirect/phpcodesniffer-composer-installer": true


### PR DESCRIPTION
This changes the composer type to `wordpress-plugin`, so custom installer rules will work as expected.