### PR TITLE
add divider above byline slot

### DIFF
--- a/client/src/block-editor.js
+++ b/client/src/block-editor.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { __ } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
 import { PluginPostStatusInfo } from '@wordpress/edit-post';
+import { __experimentalDivider as Divider } from '@wordpress/components';
 
 // Components.
 import BylineSlot from 'components/byline-slot';
@@ -15,6 +16,7 @@ import './styles/styles.scss';
 const BylineSlotFill = () => (
   <PluginPostStatusInfo>
     <div style={{ width: '100%' }}>
+      <Divider />
       <p>
         <strong>{__('Byline', 'byline-manager')}</strong>
       </p>


### PR DESCRIPTION
Adds a `<Divider />` above the Byline slot to give it more visual separation within the `PluginPostStatusInfo` panel in the editor.

| Before         | After           |
| ----------- | ----------- |
| <img width="280" alt="before" src="https://user-images.githubusercontent.com/1542278/160925997-4f4287e1-dd06-4c49-9ad6-4294c515786e.png"> | <img width="280" alt="after" src="https://user-images.githubusercontent.com/1542278/160926029-cc5add7a-c376-44d6-8b5f-98e7ab04d015.png"> |

