### PR TITLE
Add a `.gitignore.dist` file

### DIFF
--- a/.gitignore.dist
+++ b/.gitignore.dist
@@ -1,0 +1,13 @@
+.DS_Store
+.vscode
+Thumbs.db
+phpcs.xml
+phpunit.xml
+wp-cli.local.yml
+node_modules/
+*.sql
+*.tar.gz
+*.zip
+
+# Client build files
+/vendor


### PR DESCRIPTION
This commit will include built files for this plugin in VIP deploys in cases where the plugin is included via submodule.