### PR TITLE
Allow saving an empty set of bylines

### DIFF
--- a/.buddy/PushToBuiltBranch.yml
+++ b/.buddy/PushToBuiltBranch.yml
@@ -13,7 +13,7 @@
     docker_image_name: "library/node"
     docker_image_tag: "16"
     execute_commands:
-    - "npm ci --cache .npm"
+    - "npm ci --legacy-peer-deps --cache .npm" # Use old behavior to allow our use of Webpack 5 until babel-loader is updated to 8+.
     volume_mappings:
     - "/:/buddy/byline-manager"
     cache_base_image: true

--- a/.editorconfig
+++ b/.editorconfig
@@ -14,7 +14,7 @@ trim_trailing_whitespace = true
 indent_style = tab
 indent_size = 4
 
-[{.jshintrc,*.js,*.json,*.yml,*.css,*.scss}]
+[{.jshintrc,*.js,*.jsx,*.json,*.yml,*.css,*.scss}]
 indent_style = space
 indent_size = 2
 

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -11,5 +11,5 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: '16'
-      - run: npm ci
+      - run: npm ci --legacy-peer-deps # Use old behavior to allow our use of Webpack 5 until babel-loader is updated to 8+.
       - run: npm test

--- a/client/src/components/byline-slot/index.jsx
+++ b/client/src/components/byline-slot/index.jsx
@@ -1,7 +1,9 @@
 /* global bylineData */
 
 import React, { useEffect } from 'react';
+import { Spinner } from '@wordpress/components';
 import { dispatch, useDispatch, useSelect } from '@wordpress/data';
+import { Fragment } from '@wordpress/element';
 
 // Components.
 import createSaveByline from '../../utils/create-save-byline';
@@ -33,32 +35,42 @@ const BylineSlot = () => {
   const saveByline = createSaveByline(dispatch);
 
   useEffect(() => {
-    saveByline(profiles);
+    if (null !== profiles) {
+      saveByline(profiles);
+    }
   }, [profiles]);
 
   return (
     <div className="components-base-control">
-      <BylineAutocomplete
-        profiles={profiles}
-        onUpdate={addProfile}
-        profilesApiUrl={profilesApiUrl}
-        addAuthorPlaceholder={addAuthorPlaceholder}
-        addAuthorLabel={addAuthorLabel}
-      />
-      <BylineFreeform
-        onUpdate={addProfile}
-        addFreeformLabel={addFreeformLabel}
-        addFreeformPlaceholder={addFreeformPlaceholder}
-        addFreeformButtonLabel={addFreeformButtonLabel}
-      />
-      <BylineList
-        profiles={profiles}
-        onSortEnd={reorderProfile}
-        lockAxis="y"
-        helperClass="byline-list-item"
-        removeItem={removeProfile}
-        removeAuthorLabel={removeAuthorLabel}
-      />
+      {null === profiles ? (
+        <div style={{ textAlign: 'center' }}>
+          <Spinner />
+        </div>
+      ) : (
+        <Fragment>
+          <BylineAutocomplete
+            profiles={profiles}
+            onUpdate={addProfile}
+            profilesApiUrl={profilesApiUrl}
+            addAuthorPlaceholder={addAuthorPlaceholder}
+            addAuthorLabel={addAuthorLabel}
+          />
+          <BylineFreeform
+            onUpdate={addProfile}
+            addFreeformLabel={addFreeformLabel}
+            addFreeformPlaceholder={addFreeformPlaceholder}
+            addFreeformButtonLabel={addFreeformButtonLabel}
+          />
+          <BylineList
+            profiles={profiles}
+            onSortEnd={reorderProfile}
+            lockAxis="y"
+            helperClass="byline-list-item"
+            removeItem={removeProfile}
+            removeAuthorLabel={removeAuthorLabel}
+          />
+        </Fragment>
+      )}
     </div>
   );
 };

--- a/client/src/data/index.js
+++ b/client/src/data/index.js
@@ -41,6 +41,7 @@ const store = {
           byline: {
             profiles: modifyReducer(state.byline.profiles, action),
           },
+          profilesHydrated: state.profilesHydrated,
         };
 
       default:

--- a/client/src/data/modules/hydrate/index.js
+++ b/client/src/data/modules/hydrate/index.js
@@ -39,7 +39,7 @@ export const actionReceiveHydratedProfiles = (profiles) => ({
 });
 
 export const getProfiles = (state) => (
-  state.byline.profiles || []
+  state.profilesHydrated ? state.byline.profiles || [] : null
 );
 
 export function* resolveProfiles() {

--- a/client/src/utils/create-save-byline.js
+++ b/client/src/utils/create-save-byline.js
@@ -4,10 +4,6 @@ import transformHydratedProfiles from './transform-hydrate-profiles';
  * Create a function to save bylines to meta.
  */
 const createSaveByline = (dispatch) => (profiles) => {
-  if (! profiles.length) {
-    return profiles;
-  }
-
   const preparedProfiles = transformHydratedProfiles(profiles);
 
   // Save byline tax term relationships.


### PR DESCRIPTION
When using the block editor, once a post has been saved with a byline, it isn't currently possible to remove all bylines from the post and then save it without bylines. Clicking "Remove" on the last byline does appear to delete it from the post, but the byline will stay assigned even after saving the post, and it will be visible again the next time the editor loads.

This PR would address this problem in a few steps:

- In `createSaveByline()`, which actually calls `dispatch('core/editor').editPost()`, remove the early return that occurs when passing a 0-length array. This allows the empty array to make it to `editPost()`.

- Until saved profile data is hydrated by the server, return `null` instead of an empty array when attempting to `getProfiles()` assigned to the post. This `null` indicates that the profile data isn't ready for use. 

- Check for the `null` state in `BylineSlot`, and don't call `saveByline()` until profile data is hydrated. 

Why add a new `null` state to `getProfiles()`? If `getProfiles()` still returned an empty array before profile data was hydrated, that empty array would be passed to `saveByline()`, and, given the other changes in this PR, now that empty array would be saved, deleting all bylines assigned to the post before hydration had a chance to complete.