### PR TITLE
GraphQL: Fix array access offset error in profiles resolver

### DIFF
--- a/inc/graphql.php
+++ b/inc/graphql.php
@@ -100,6 +100,7 @@ function register_byline_types() {
 					'description' => __( 'Byline profiles.', 'byline-manager' ),
 					'resolve'     => function ( WPGraphQL\Model\Post $post ) {
 						$byline_data = get_post_meta( $post->ID, 'byline', true );
+
 						if ( ! $byline_data ) {
 							return null;
 						}

--- a/inc/graphql.php
+++ b/inc/graphql.php
@@ -100,6 +100,10 @@ function register_byline_types() {
 					'description' => __( 'Byline profiles.', 'byline-manager' ),
 					'resolve'     => function ( WPGraphQL\Model\Post $post ) {
 						$byline_data = get_post_meta( $post->ID, 'byline', true );
+						
+						if ( ! $byline_data ) {
+							return null;
+						}
 
 						$bylines = array_map(
 							function( $profile ) {

--- a/inc/graphql.php
+++ b/inc/graphql.php
@@ -100,7 +100,6 @@ function register_byline_types() {
 					'description' => __( 'Byline profiles.', 'byline-manager' ),
 					'resolve'     => function ( WPGraphQL\Model\Post $post ) {
 						$byline_data = get_post_meta( $post->ID, 'byline', true );
-						
 						if ( ! $byline_data ) {
 							return null;
 						}


### PR DESCRIPTION
This adds a check for the byline post meta value and bails early if no meta is found before checking for the `$byline_data['profiles']` property to avoid a PHP Fatal error in PHP8.