### PR TITLE
Utility doc updates

### DIFF
--- a/inc/class-utils.php
+++ b/inc/class-utils.php
@@ -130,7 +130,7 @@ class Utils {
 	 * @param int   $post_id     ID for the post to modify.
 	 * @param array $byline_meta {
 	 *     Metadata about the byline to store.
-	 *     Example array for $byline meta:
+	 *     Example array for $byline_meta:
 	 *
 	 *     [
 	 *         'byline_entries' => [

--- a/inc/class-utils.php
+++ b/inc/class-utils.php
@@ -128,7 +128,7 @@ class Utils {
 	 * Set the byline for a post given raw meta information.
 	 *
 	 * @param int   $post_id     ID for the post to modify.
-	 * @param array $byline_meta {
+	 * @param array $byline_meta.
 	 *     Metadata about the byline to store.
 	 *     Example array for $byline_meta:
 	 *

--- a/inc/class-utils.php
+++ b/inc/class-utils.php
@@ -128,32 +128,32 @@ class Utils {
 	 * Set the byline for a post given raw meta information.
 	 *
 	 * @param int   $post_id     ID for the post to modify.
-	 * @param array $byline_meta.
-	 *     Metadata about the byline to store.
-	 *     Example array for $byline_meta:
+	 * @param array $byline_meta Metadata about the byline to store.
 	 *
-	 *     [
-	 *         'byline_entries' => [
-	 *             [
-	 *                 'type' => 'byline_id',
-	 *                 'atts' => [
-	 *                     'byline_id' => 123, // Term ID, int.
-	 *                 ],
-	 *             ],
-	 *             [
-	 *                 'type' => 'byline_id',
-	 *                 'atts' => [
-	 *                     'byline_id' => 456, // Term ID, int.
-	 *                 ],
-	 *             ],
-	 *             [
-	 *                 'type' => 'text',
-	 *                 'atts' => [
-	 *                     'text' => 'A Text-only Author', // A text profile, string.
-	 *                 ],
+	 * Example array for $byline_meta:
+	 *
+	 * [
+	 *     'byline_entries' => [
+	 *         [
+	 *             'type' => 'byline_id',
+	 *             'atts' => [
+	 *                 'byline_id' => 123, // Term ID, int.
 	 *             ],
 	 *         ],
-	 *     ]
+	 *         [
+	 *             'type' => 'byline_id',
+	 *             'atts' => [
+	 *                 'byline_id' => 456, // Term ID, int.
+	 *             ],
+	 *         ],
+	 *         [
+	 *             'type' => 'text',
+	 *             'atts' => [
+	 *                 'text' => 'A Text-only Author', // A text profile, string.
+	 *             ],
+	 *         ],
+	 *     ],
+	 * ].
 	 */
 	public static function set_post_byline( int $post_id, array $byline_meta ) {
 		$default_args = [

--- a/inc/class-utils.php
+++ b/inc/class-utils.php
@@ -130,14 +130,30 @@ class Utils {
 	 * @param int   $post_id     ID for the post to modify.
 	 * @param array $byline_meta {
 	 *     Metadata about the byline to store.
+	 *     Example array for $byline meta:
 	 *
-	 *     @type string $source     Optional. One of 'profiles' or 'override'.
-	 *                              defaults to 'profiles'.
-	 *     @type string $override   Optional. Byline override text. Defaults to
-	 *                              empty string.
-	 *     @type array  $byline_ids Optional. Byline term ids. Defaults to empty
-	 *                              array.
-	 * }
+	 *     [
+	 *         'byline_entries' => [
+	 *             [
+	 *                 'type' => 'byline_id',
+	 *                 'atts' => [
+	 *                     'byline_id' => 123, // Term ID, int.
+	 *                 ],
+	 *             ],
+	 *             [
+	 *                 'type' => 'byline_id',
+	 *                 'atts' => [
+	 *                     'byline_id' => 456, // Term ID, int.
+	 *                 ],
+	 *             ],
+	 *             [
+	 *                 'type' => 'text',
+	 *                 'atts' => [
+	 *                     'text' => 'A Text-only Author', // A text profile, string.
+	 *                 ],
+	 *             ],
+	 *         ],
+	 *     ]
 	 */
 	public static function set_post_byline( int $post_id, array $byline_meta ) {
 		$default_args = [

--- a/inc/models/class-profile.php
+++ b/inc/models/class-profile.php
@@ -99,7 +99,7 @@ class Profile {
 	}
 
 	/**
-	 * Get a profile object based on its term id.
+	 * Get a profile object based on its profile post ID or object.
 	 *
 	 * @param int|\WP_Post $post Post ID or object of a profile.
 	 * @return Profile|false


### PR DESCRIPTION
* Updates the array format documentation for `\Byline_Manager\Utils::set_post_byline()`'s second parameter. Previously, the documentation reflected a much older version of the function and was no longer relevant.
* Updates the comment for \Byline_Manager\Profile::get_by_post()` which had been copied from another method without update.