### PR TITLE
Refactor rest profile search query to return 10 results, orderby relevance

### DIFF
--- a/inc/rest-api.php
+++ b/inc/rest-api.php
@@ -64,7 +64,6 @@ function rest_profile_search( \WP_REST_Request $request ) {
 			'numberposts'      => 10,
 			's'                => $request->get_param( 's' ),
 			'suppress_filters' => false,
-			// Ensure autocomplete returns with the most relevant results.
 			'orderby'          => 'relevance',
 		]
 	);

--- a/inc/rest-api.php
+++ b/inc/rest-api.php
@@ -64,9 +64,11 @@ function rest_profile_search( \WP_REST_Request $request ) {
 			'numberposts'      => 10,
 			's'                => $request->get_param( 's' ),
 			'suppress_filters' => false,
+			// Ensure autocomplete returns with the most relevant results.
 			'orderby'          => 'relevance',
 		]
 	);
+
 	$profiles = array_filter(
 		array_map(
 			[ 'Byline_Manager\Models\Profile', 'get_by_post' ],

--- a/inc/rest-api.php
+++ b/inc/rest-api.php
@@ -61,10 +61,10 @@ function rest_profile_search( \WP_REST_Request $request ) {
 	$posts    = get_posts( // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.get_posts_get_posts
 		[
 			'post_type'        => PROFILE_POST_TYPE,
+			'numberposts'      => 10,
 			's'                => $request->get_param( 's' ),
 			'suppress_filters' => false,
-			'orderby'          => 'title',
-			'order'            => 'asc',
+			'orderby'          => 'relevance',
 		]
 	);
 	$profiles = array_filter(

--- a/inc/rest-api.php
+++ b/inc/rest-api.php
@@ -58,7 +58,7 @@ add_action( 'rest_api_init', __NAMESPACE__ . '\register_rest_routes' );
  * @return \WP_REST_Response REST API response.
  */
 function rest_profile_search( \WP_REST_Request $request ) {
-	$posts    = get_posts( // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.get_posts_get_posts
+	$posts = get_posts( // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.get_posts_get_posts
 		[
 			'post_type'        => PROFILE_POST_TYPE,
 			'numberposts'      => 10,


### PR DESCRIPTION
## Summary
This PR will change profile search query parameters to return 10 profiles instead of 5, as well as ordering the profile search results by the default WordPress search ordering (by `relevance` in descending order).

## Context
We have encountered a couple scenarios on Lede where authors are unable to find the Byline they want due primarily to the custom `orderby` param Byline Manager uses. 

For example: LA Taco has many byline profiles that contain the word `taco` in profile post content. When authors search for profiles via the Byline Manager autocomplete field on the post edit screen, the current functionality will return all those profiles, then reorder them by their title in ascending order. That combined with the current limit of 5 profiles returned means the most relevant profile(s) (those with the word "taco" in the profile title) are not displayed.