### PR TITLE
Hide the `Bylinelist` if profiles are empty

### DIFF
--- a/client/src/components/byline-slot-wrapper/index.jsx
+++ b/client/src/components/byline-slot-wrapper/index.jsx
@@ -44,14 +44,16 @@ const BylineSlotWrapper = ({
           addFreeformPlaceholder={addFreeformPlaceholder || bylineData.addFreeformPlaceholder}
           addFreeformButtonLabel={addFreeformButtonLabel || bylineData.addFreeformButtonLabel}
         />
-        <BylineList
-          profiles={profiles}
-          onSortEnd={reorderProfile}
-          lockAxis="y"
-          helperClass="byline-list-item"
-          removeItem={removeProfile}
-          removeAuthorLabel={removeAuthorLabel || bylineData.removeAuthorLabel}
-        />
+        {0 !== profiles.length ? (
+          <BylineList
+            profiles={profiles}
+            onSortEnd={reorderProfile}
+            lockAxis="y"
+            helperClass="byline-list-item"
+            removeItem={removeProfile}
+            removeAuthorLabel={removeAuthorLabel || bylineData.removeAuthorLabel}
+          />
+        ) : null}
       </Fragment>
     )}
   </div>


### PR DESCRIPTION
When additional Byline panels are added, this adds more margin due to the empty component div.