### PR TITLE
Miscellaneous updates

### DIFF
--- a/client/src/block-editor.js
+++ b/client/src/block-editor.js
@@ -1,5 +1,4 @@
 // External dependencies.
-import React from 'react';
 import { __ } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
 
@@ -8,10 +7,10 @@ import {
   BylineManagerPanelInfoProvider,
   BylineManagerPanelInfo,
   BylineSlotContainer,
-} from 'containers';
+} from './containers';
 
-// Register our store.
-import { store } from './store';
+// Get and register our store.
+import store from './store';
 
 // Styles.
 import './styles/styles.scss';

--- a/client/src/components/byline-autocomplete/index.jsx
+++ b/client/src/components/byline-autocomplete/index.jsx
@@ -1,6 +1,6 @@
 // External dependencies.
-import React from 'react';
 import { useState, useEffect } from '@wordpress/element';
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import Autocomplete from 'react-autocomplete';
 
@@ -8,6 +8,7 @@ import Autocomplete from 'react-autocomplete';
 import { useDebounce } from '@uidotdev/usehooks';
 
 const BylineAutocomplete = ({
+  id,
   profiles,
   onUpdate,
   profilesApiUrl,
@@ -40,7 +41,7 @@ const BylineAutocomplete = ({
     className: 'components-text-control__input',
     type: 'text',
     placeholder: addAuthorPlaceholder,
-    id: 'profiles_autocomplete',
+    id,
     onKeyDown: (e) => {
       // If the user hits 'enter', stop the parent form from submitting.
       if (13 === e.keyCode) {
@@ -59,7 +60,7 @@ const BylineAutocomplete = ({
     <div className="profile-controls components-base-control__field">
       <label
         className="components-base-control__label"
-        htmlFor="profiles_autocomplete"
+        htmlFor={id}
       >
         {addAuthorLabel}
       </label>
@@ -69,13 +70,13 @@ const BylineAutocomplete = ({
         value={search}
         getItemValue={(item) => item.name}
         wrapperStyle={{ position: 'relative', display: 'block' }}
-        onSelect={(value, item) => {
+        onSelect={(__, item) => {
           setSearch('');
           setSearchResults([]);
 
           onUpdate(item);
         }}
-        onChange={(event, next) => setSearch(next)}
+        onChange={(__, next) => setSearch(next)}
         renderMenu={(children) => (
           <div className="menu">
             {children}
@@ -83,8 +84,15 @@ const BylineAutocomplete = ({
         )}
         renderItem={(item, isHighlighted) => (
           <div
-            className={`item ${isHighlighted ? 'item-highlighted' : ''}`}
             key={item.id}
+            className={
+              classNames(
+                'item',
+                {
+                  'item-highlighted': isHighlighted,
+                }
+              )
+            }
           >
             {item.name}
           </div>
@@ -97,7 +105,12 @@ const BylineAutocomplete = ({
   );
 };
 
+BylineAutocomplete.defaultProps = {
+  id: 'profiles_autocomplete',
+};
+
 BylineAutocomplete.propTypes = {
+  id: PropTypes.string,
   profiles: PropTypes.arrayOf(PropTypes.shape({
     id: PropTypes.oneOfType([
       PropTypes.number,

--- a/client/src/components/byline-freeform/index.jsx
+++ b/client/src/components/byline-freeform/index.jsx
@@ -1,10 +1,10 @@
 // External dependencies.
-import React from 'react';
 import PropTypes from 'prop-types';
 import { Button } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 
 const BylineFreeform = ({
+  id,
   addFreeformLabel,
   addFreeformPlaceholder,
   addFreeformButtonLabel,
@@ -32,15 +32,15 @@ const BylineFreeform = ({
     >
       <label
         className="components-base-control__label"
-        htmlFor="byline_freeform"
+        htmlFor={id}
       >
         {addFreeformLabel}
       </label>
       <div className="freeformInputGrp">
         <input
           className="components-text-control__input"
-          id="byline_freeform"
-          name="byline_freeform"
+          id={id}
+          name={id}
           onChange={(e) => {
             setTextByline(e.target.value);
           }}
@@ -51,9 +51,9 @@ const BylineFreeform = ({
         <Button
           label={addFreeformButtonLabel}
           className="button"
+          size="small"
           variant="secondary"
           disabled={! textByline}
-          isSmall
           onClick={onSubmit}
         >
           {addFreeformButtonLabel}
@@ -63,7 +63,12 @@ const BylineFreeform = ({
   );
 };
 
+BylineFreeform.defaultProps = {
+  id: 'byline_freeform',
+};
+
 BylineFreeform.propTypes = {
+  id: PropTypes.string,
   addFreeformLabel: PropTypes.string.isRequired,
   addFreeformPlaceholder: PropTypes.string.isRequired,
   addFreeformButtonLabel: PropTypes.string.isRequired,

--- a/client/src/components/byline-list-item/index.jsx
+++ b/client/src/components/byline-list-item/index.jsx
@@ -16,7 +16,7 @@ const BylineListItem = SortableElement(({
       label={removeAuthorLabel}
       isDestructive
       variant="secondary"
-      isSmall
+      size="small"
       onClick={(e) => {
         e.preventDefault();
         removeItem();

--- a/client/src/components/byline-metabox/index.js
+++ b/client/src/components/byline-metabox/index.js
@@ -1,7 +1,6 @@
 /* global bylineData */
 
 // External dependencies.
-import React from 'react';
 import PropTypes from 'prop-types';
 
 // Internal dependencies.

--- a/client/src/components/byline-profiles/index.js
+++ b/client/src/components/byline-profiles/index.js
@@ -1,5 +1,4 @@
 // External dependencies.
-import React from 'react';
 import PropTypes from 'prop-types';
 import { useState, useEffect } from '@wordpress/element';
 import classNames from 'classnames';
@@ -38,7 +37,7 @@ const SortableItem = SortableElement(({
     <Button
       label={removeAuthorLabel}
       isDestructive
-      isSmall
+      size="small"
       variant="secondary"
       onClick={(e) => {
         e.preventDefault();
@@ -72,6 +71,8 @@ const BylineList = SortableContainer(({
 ));
 
 const BylineProfiles = ({
+  autocompleteInputId,
+  freeformInputId,
   addAuthorLabel,
   addAuthorPlaceholder,
   addFreeformButtonLabel,
@@ -123,7 +124,7 @@ const BylineProfiles = ({
     className: 'components-text-control__input',
     type: 'text',
     placeholder: addAuthorPlaceholder,
-    id: 'profiles_autocomplete',
+    id: autocompleteInputId,
     onKeyDown: (e) => {
       // If the user hits 'enter', stop the parent form from submitting.
       if (13 === e.keyCode) {
@@ -145,7 +146,7 @@ const BylineProfiles = ({
           {/* eslint-disable jsx-a11y/label-has-for */}
           <label
             className="components-base-control__label"
-            htmlFor="profiles_autocomplete"
+            htmlFor={autocompleteInputId}
           >
             {addAuthorLabel}
           </label>
@@ -155,12 +156,12 @@ const BylineProfiles = ({
             value={search}
             getItemValue={(item) => item.name}
             wrapperStyle={{ position: 'relative', display: 'block' }}
-            onSelect={(item, next) => {
+            onSelect={(__, next) => {
               setSearch('');
               setSearchResults([]);
               setProfiles([...profiles, next]);
             }}
-            onChange={(event, next) => setSearch(next)}
+            onChange={(__, next) => setSearch(next)}
             renderMenu={(children) => (
               <div className="menu">
                 {children}
@@ -186,15 +187,15 @@ const BylineProfiles = ({
         <div className="freeform-controls components-base-control__field">
           <label
             className="components-base-control__label"
-            htmlFor="byline_freeform"
+            htmlFor={freeformInputId}
           >
             {addFreeformLabel}
           </label>
           <div className="freeformInputGrp">
             <input
               className="components-text-control__input"
-              id="byline_freeform"
-              name="byline_freeform"
+              id={freeformInputId}
+              name={freeformInputId}
               onChange={(e) => {
                 setValue(e.target.value);
               }}
@@ -206,8 +207,8 @@ const BylineProfiles = ({
               label={addFreeformButtonLabel}
               className="button"
               disabled={! value}
+              size="small"
               variant="secondary"
-              isSmall
               onClick={(e) => {
                 e.preventDefault();
                 const newItem = {
@@ -239,7 +240,14 @@ const BylineProfiles = ({
   );
 };
 
+BylineProfiles.defaultProps = {
+  autocompleteInputId: 'profiles_autocomplete',
+  freeformInputId: 'byline_freeform',
+};
+
 BylineProfiles.propTypes = {
+  autocompleteInputId: PropTypes.string,
+  freeformInputId: PropTypes.string,
   addAuthorLabel: PropTypes.string.isRequired,
   addAuthorPlaceholder: PropTypes.string.isRequired,
   addFreeformButtonLabel: PropTypes.string.isRequired,

--- a/client/src/components/byline-slot-wrapper/index.jsx
+++ b/client/src/components/byline-slot-wrapper/index.jsx
@@ -1,7 +1,6 @@
 /* global bylineData */
 
 // External dependencies.
-import React from 'react';
 import PropTypes from 'prop-types';
 import { Spinner } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';

--- a/client/src/components/byline-slot-wrapper/index.jsx
+++ b/client/src/components/byline-slot-wrapper/index.jsx
@@ -11,17 +11,19 @@ import BylineFreeform from '../byline-freeform';
 import BylineList from '../byline-list';
 
 const BylineSlotWrapper = ({
-  profiles,
-  addProfile,
-  removeProfile,
-  reorderProfile,
   addAuthorLabel,
   addAuthorPlaceholder,
-  removeAuthorLabel,
+  addFreeformButtonLabel,
   addFreeformLabel,
   addFreeformPlaceholder,
-  addFreeformButtonLabel,
+  addProfile,
+  autocompleteInputId,
+  freeformInputId,
+  profiles,
   profilesApiUrl,
+  removeAuthorLabel,
+  removeProfile,
+  reorderProfile,
 }) => (
   <div className="components-base-control">
     {null === profiles ? (
@@ -31,6 +33,7 @@ const BylineSlotWrapper = ({
     ) : (
       <Fragment>
         <BylineAutocomplete
+          id={autocompleteInputId}
           profiles={profiles}
           onUpdate={addProfile}
           profilesApiUrl={profilesApiUrl || bylineData.profilesApiUrl}
@@ -38,6 +41,7 @@ const BylineSlotWrapper = ({
           addAuthorLabel={addAuthorLabel || bylineData.addAuthorLabel}
         />
         <BylineFreeform
+          id={freeformInputId}
           onUpdate={addProfile}
           addFreeformLabel={addFreeformLabel || bylineData.addFreeformLabel}
           addFreeformPlaceholder={addFreeformPlaceholder || bylineData.addFreeformPlaceholder}
@@ -59,17 +63,27 @@ const BylineSlotWrapper = ({
 );
 
 BylineSlotWrapper.defaultProps = {
-  profiles: [],
   addAuthorLabel: null,
   addAuthorPlaceholder: null,
-  removeAuthorLabel: null,
+  addFreeformButtonLabel: null,
   addFreeformLabel: null,
   addFreeformPlaceholder: null,
-  addFreeformButtonLabel: null,
+  autocompleteInputId: 'profiles_autocomplete',
+  freeformInputId: 'byline_freeform',
+  profiles: [],
   profilesApiUrl: null,
+  removeAuthorLabel: null,
 };
 
 BylineSlotWrapper.propTypes = {
+  addAuthorLabel: PropTypes.string,
+  addAuthorPlaceholder: PropTypes.string,
+  addFreeformButtonLabel: PropTypes.string,
+  addFreeformLabel: PropTypes.string,
+  addFreeformPlaceholder: PropTypes.string,
+  addProfile: PropTypes.func.isRequired,
+  autocompleteInputId: PropTypes.string,
+  freeformInputId: PropTypes.string,
   profiles: PropTypes.arrayOf(PropTypes.shape({
     id: PropTypes.oneOfType([
       PropTypes.number,
@@ -82,16 +96,10 @@ BylineSlotWrapper.propTypes = {
       PropTypes.string,
     ]),
   })),
-  addProfile: PropTypes.func.isRequired,
+  profilesApiUrl: PropTypes.string,
+  removeAuthorLabel: PropTypes.string,
   removeProfile: PropTypes.func.isRequired,
   reorderProfile: PropTypes.func.isRequired,
-  addAuthorLabel: PropTypes.string,
-  addAuthorPlaceholder: PropTypes.string,
-  removeAuthorLabel: PropTypes.string,
-  addFreeformLabel: PropTypes.string,
-  addFreeformPlaceholder: PropTypes.string,
-  addFreeformButtonLabel: PropTypes.string,
-  profilesApiUrl: PropTypes.string,
 };
 
 export default BylineSlotWrapper;

--- a/client/src/components/user-link-metabox/index.js
+++ b/client/src/components/user-link-metabox/index.js
@@ -1,9 +1,8 @@
 // External dependencies.
-import React from 'react';
 import PropTypes from 'prop-types';
 import { useState, useEffect } from '@wordpress/element';
-import Autocomplete from 'react-autocomplete';
 import { Button } from '@wordpress/components';
+import Autocomplete from 'react-autocomplete';
 
 // Hooks.
 import { useDebounce } from '@uidotdev/usehooks';
@@ -72,7 +71,7 @@ const UserLinkMetaBox = ({
             className="button button-link-delete button-small"
             variant="secondary"
             isDestructive
-            isSmall
+            size="small"
             onClick={(e) => {
               e.preventDefault();
               setUser({});
@@ -87,12 +86,12 @@ const UserLinkMetaBox = ({
         items={searchResults}
         value={search}
         getItemValue={(item) => item.name}
-        onSelect={(event, next) => {
+        onSelect={(__, next) => {
           setUser(next);
           setSearch('');
           setSearchResults([]);
         }}
-        onChange={(event, next) => setSearch(next)}
+        onChange={(__, next) => setSearch(next)}
         isItemSelectable={(item) => ! item.linked}
         renderMenu={(children) => (
           <div className="menu">

--- a/client/src/containers/container/index.jsx
+++ b/client/src/containers/container/index.jsx
@@ -1,5 +1,4 @@
 // External dependencies.
-import React from 'react';
 import PropTypes from 'prop-types';
 import { dispatch, useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
@@ -9,10 +8,10 @@ import setBylineMeta from '../../utils/set-byline';
 import BylineSlotWrapper from '../../components/byline-slot-wrapper';
 
 const BylineSlotContainer = ({
-  store,
   metaKey,
+  store,
 }) => {
-  const profiles = useSelect((select) => select(store).getProfiles());
+  const profiles = useSelect((select) => select(store).getProfiles(), []);
 
   const {
     actionAddProfile: addProfile,

--- a/client/src/init-byline-metabox.js
+++ b/client/src/init-byline-metabox.js
@@ -1,6 +1,5 @@
 /* global bylineData */
 
-import React from 'react';
 import ReactDOM from 'react-dom';
 import BylineMetaBox from 'components/byline-metabox';
 

--- a/client/src/init-user-link-metabox.js
+++ b/client/src/init-user-link-metabox.js
@@ -1,6 +1,5 @@
 /* global bylineData */
 
-import React from 'react';
 import ReactDOM from 'react-dom';
 import UserLinkMetaBox from 'components/user-link-metabox';
 

--- a/client/src/store/actions/modify-actions.js
+++ b/client/src/store/actions/modify-actions.js
@@ -5,17 +5,17 @@ import { MODIFY_ACTION_TYPES } from '../actions-types';
  * Create action to add a single hydrated profile to an array of
  * hydrated profiles.
  *
- * @param {Object} bylineToAdd Hydrated profile.
+ * @param {Object} profile Hydrated profile.
  */
-export const actionAddProfile = (bylineToAdd) => ({
+export const actionAddProfile = (profile) => ({
   type: MODIFY_ACTION_TYPES.ADD_PROFILE,
-  payload: bylineToAdd,
+  payload: profile,
 });
 
 /**
  * Create action to remove a profile by ID from the current array of profiles.
  *
- * @param {String} id The hydrated profile ID to be removed.
+ * @param {string} id The hydrated profile ID to be removed.
  */
 export const actionRemoveProfile = (id) => ({
   type: MODIFY_ACTION_TYPES.REMOVE_PROFILE,
@@ -25,7 +25,7 @@ export const actionRemoveProfile = (id) => ({
 /**
  * Create action to reorder profiles currently selected.
  *
- * @param {Object} indices old and new index for moved item.
+ * @param {Object} indices Old and new index for moved item.
  */
 export const actionReorderProfile = (indices) => ({
   type: MODIFY_ACTION_TYPES.REORDER_PROFILE,

--- a/client/src/store/creator.js
+++ b/client/src/store/creator.js
@@ -9,17 +9,17 @@ import reducer from './reducer';
 import controls from './controls';
 
 /**
- * Byline Manager store registration.
+ * Byline Manager Redux store registration.
  *
  * @example
  * ```js
- * import { storeCreator } from 'path/to/byline/manager/store';
+ * import storeCreator from 'path/to/byline/manager/creator';
  *
  * storeCreator(MY_STORE_CUSTOM_KEY, 'meta_key');
  * ```
  *
- * @param {String} storeKey Redux store key.
- * @param {String} metaKey Meta key.
+ * @param {string} storeKey Redux store key.
+ * @param {string} metaKey Meta key. Default: 'byline'.
  */
 const creator = (storeKey, metaKey = 'byline') => {
   const store = createReduxStore(
@@ -34,7 +34,7 @@ const creator = (storeKey, metaKey = 'byline') => {
       resolvers: {
         getProfiles: () => resolveProfiles(storeKey, metaKey),
       },
-    }
+    },
   );
 
   register(store);

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -8,7 +8,4 @@ const store = STORE_KEY;
 // Create the default Byline Manager Redux store.
 creator(store);
 
-export {
-  store,
-  creator as storeCreator,
-};
+export default store;

--- a/inc/assets.php
+++ b/inc/assets.php
@@ -20,7 +20,7 @@ define( 'BYLINE_MANAGER_ASSET_MODE', BYLINE_MANAGER_ASSET_MAP['mode'] ?? 'produc
  *
  * @param string $hook Page suffix.
  */
-function admin_enqueue_scripts( $hook ) {
+function admin_enqueue_scripts( $hook ): void {
 	if (
 		in_array( $hook, [ 'post-new.php', 'post.php' ], true )
 		&& (
@@ -50,7 +50,7 @@ add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\admin_enqueue_scripts' );
  *
  * @since 1.0.0
  */
-function action_enqueue_block_editor_assets() {
+function action_enqueue_block_editor_assets(): void {
 	// Only enqueue the script to register the scripts if supported.
 	if ( ! Utils::is_post_type_supported() ) {
 		return;
@@ -72,9 +72,9 @@ add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\action_enqueue_bloc
 /**
  * Localizes an admin script with Byline data.
  *
- * @param  string $handle The script handle.
+ * @param string $handle The script handle.
  */
-function localize_admin_script( $handle ) {
+function localize_admin_script( $handle ): void {
 	// Build the byline metabox data.
 	$byline_metabox_data = Utils::get_byline_meta_for_post();
 	if ( ! empty( $byline_metabox_data['profiles'] ) ) {

--- a/inc/rest-api.php
+++ b/inc/rest-api.php
@@ -96,12 +96,13 @@ function rest_profile_search( WP_REST_Request $request ): WP_REST_Response {
 function rest_hydrate_profiles( WP_REST_Request $request ): WP_REST_Response {
 	$byline_profiles = $request['profiles'] ?? [];
 	$profiles        = [];
+
 	// Check to see if the current user has profile associated with their user.
 	$current_user_profile_id = get_user_meta( get_current_user_id(), 'profile_id', true );
 	$current_user_profile    = Profile::get_by_post( $current_user_profile_id );
 
 	/**
-	 * Determine wether to auto set byline if a user object has a byline associated with it.
+	 * Determine whether to auto set byline if a user object has a byline associated with it.
 	 *
 	 * @param bool $value Whether or not to auto set profile.
 	 */
@@ -112,8 +113,6 @@ function rest_hydrate_profiles( WP_REST_Request $request ): WP_REST_Response {
 	 * Else return the user's associated profile if one was found and $auto_set_user_profile === true.
 	 */
 	if ( ! empty( $byline_profiles ) ) {
-		$index = 0;
-
 		foreach ( $byline_profiles as $entry ) {
 			if (
 				! empty( $entry['type'] )
@@ -134,10 +133,7 @@ function rest_hydrate_profiles( WP_REST_Request $request ): WP_REST_Response {
 					'name' => $text_profile->display_name,
 				];
 			}
-			$index++;
 		}
-
-		$byline_profiles = $profiles;
 	} elseif ( $current_user_profile instanceof Profile && $auto_set_user_profile ) {
 		$profiles[] = get_profile_data_for_meta_box( $current_user_profile );
 	}


### PR DESCRIPTION
- [x] Removing import of React (not required since React 17)
- [x] Allow for components to be passed a custom input ID
- [x] Fix redux duplication registration when importing the `storeCreator` in a custom project
- [x] Pass the second param to `useSelect` to avoid unnecessary rerenders
- [x] Remove unnecessary $index from `rest_hydrate_profiles`
- [x] Misc changes