### PR TITLE
Hotfix: Allow default map_meta_cap behavior

### DIFF
--- a/inc/data-structures.php
+++ b/inc/data-structures.php
@@ -75,7 +75,6 @@ function register_profile(): void {
 				'ep_mask' => EP_AUTHORS,
 			],
 			'capability_type'     => 'post',
-			'map_meta_cap'        => false,
 			'menu_icon'           => 'dashicons-id',
 			'menu_position'       => 71,
 			'supports'            => [ 'title', 'editor', 'revisions', 'thumbnail', 'custom-fields' ],


### PR DESCRIPTION
`map_meta_cap` is `null` by default (despite what the documentation claims) and it evaluates to `true` when the post type is actually registered due to the other values we've set. We want to embrace that default behavior, and we'll do so by not setting the value at all.