### PR TITLE
Auto integrate into filter used by Post Author Name block

### DIFF
--- a/inc/core-filters.php
+++ b/inc/core-filters.php
@@ -30,6 +30,7 @@ function auto_integrate_byline( $author_name ): string {
 	return get_the_byline();
 }
 add_filter( 'the_author', __NAMESPACE__ . '\auto_integrate_byline' );
+add_filter( 'get_the_author_display_name', __NAMESPACE__ . '\auto_integrate_byline' );
 
 /**
  * Automatically integrate the byline into the `the_author_posts_link` filter.


### PR DESCRIPTION
This filters the `get_the_author_display_name` filter used by `Post Author Name` to modify the display name in the block directly.