### PR TITLE
Add support for Windows filepaths

### DIFF
--- a/byline-manager.php
+++ b/byline-manager.php
@@ -24,6 +24,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 define( 'BYLINE_MANAGER_PATH', __DIR__ . '/' );
 
+/**
+ * Helper function to validate a path before doing something with it.
+ *
+ * @param string $path The path to validate.
+ *
+ * @return bool True if the path is valid, false otherwise.
+ */
+function validate_path( string $path ) : bool {
+	return in_array( validate_file( $path ), [ 0, 2 ], true ) && file_exists( $path );
+}
+
 // Autoloader.
 require_once BYLINE_MANAGER_PATH . 'inc/autoload.php';
 

--- a/byline-manager.php
+++ b/byline-manager.php
@@ -7,7 +7,7 @@
  * Author URI:      https://alley.com
  * Text Domain:     byline-manager
  * Domain Path:     /languages
- * Version: 0.2.3
+ * Version: 0.2.4
  * Requires WP:     5.9
  * Requires PHP:    8.0
  * Tested up to:    6.3

--- a/inc/assets.php
+++ b/inc/assets.php
@@ -160,7 +160,7 @@ function get_asset_dependencies( string $asset ) : array {
 	}
 
 	// Ensure the filepath is valid.
-	if ( ! file_exists( $dependency_file ) || 0 !== validate_file( $dependency_file ) ) {
+	if ( validate_path( $dependency_file ) ) {
 		return [];
 	}
 
@@ -223,7 +223,7 @@ function get_asset_property( string $asset, string $prop ) : ?string {
  * @return array The asset map.
  */
 function read_asset_map( string $path ) : array {
-	if ( file_exists( $path ) && 0 === validate_file( $path ) ) {
+	if ( validate_path( $path ) ) {
 		ob_start();
 		include $path; // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.IncludingFile, WordPressVIPMinimum.Files.IncludingFile.UsingVariable
 		return json_decode( ob_get_clean(), true );


### PR DESCRIPTION
- Adds support for Windows filepaths by accepting both `0` and `2` as valid return values from `validate_file` (a return value of `2` means that the path is a Windows filepath, which is normal and expected on a Windows system).
- Abstracts the process of validating files for inclusion to a generic function.

Fixes #219 