### PR TITLE
Fix invalid use of useCallback

### DIFF
--- a/client/src/containers/container/index.jsx
+++ b/client/src/containers/container/index.jsx
@@ -19,9 +19,8 @@ function BylineSlotContainer({
     actionReorderProfile: reorderProfile,
   } = useDispatch(store);
 
-  const saveByline = useCallback(() => {
-    setBylineMeta(dispatch, metaKey);
-  }, [metaKey]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const saveByline = useCallback(setBylineMeta(dispatch, metaKey), [metaKey]);
 
   /**
    * Save ALL bylines to the post meta in the expected schema.


### PR DESCRIPTION
`setBylineMeta()` is a higher-order function, and was previously called using,

```js
const saveByline = setBylineMeta(dispatch, metaKey);
```

When we added useCallback, it inadvertently added a function layer, leading to `setBylineMeta()` not actually being called. This ultimately meant that bylines were not updated when saving a post.
