### PR TITLE
Fix incorrect usage of ReactDOM.createRoot()

### DIFF
--- a/client/src/init-byline-metabox.js
+++ b/client/src/init-byline-metabox.js
@@ -6,10 +6,8 @@ import BylineMetaBox from 'components/byline-metabox';
 const initBylineMetaBox = () => {
   const { bylineMetaBox } = bylineData;
 
-  ReactDOM.createRoot(
-    <BylineMetaBox bylineMetaBox={bylineMetaBox} />,
-    document.getElementById('byline-manager-metabox-root'),
-  );
+  ReactDOM.createRoot(document.getElementById('byline-manager-metabox-root'))
+    .render(<BylineMetaBox bylineMetaBox={bylineMetaBox} />);
 };
 
 export default initBylineMetaBox;

--- a/client/src/init-user-link-metabox.js
+++ b/client/src/init-user-link-metabox.js
@@ -17,17 +17,18 @@ const initUserLinkMetaBox = () => {
     usersApiUrl,
   } = bylineData;
 
-  ReactDOM.createRoot(
-    <UserLinkMetaBox
-      linkUserPlaceholder={linkUserPlaceholder}
-      linkedToLabel={linkedToLabel}
-      postId={+postId}
-      unlinkLabel={unlinkLabel}
-      user={user}
-      userAlreadyLinked={userAlreadyLinked}
-      usersApiUrl={usersApiUrl}
-    />,
-    userLinkEl,
+  ReactDOM.createRoot(userLinkEl).render(
+    (
+      <UserLinkMetaBox
+        linkUserPlaceholder={linkUserPlaceholder}
+        linkedToLabel={linkedToLabel}
+        postId={+postId}
+        unlinkLabel={unlinkLabel}
+        user={user}
+        userAlreadyLinked={userAlreadyLinked}
+        usersApiUrl={usersApiUrl}
+      />
+    ),
   );
 };
 


### PR DESCRIPTION
In a previous update, `ReactDOM.render()` was replaced with `ReactDOM.createRoot()`. The two functions are not interchangeable, and this was causing the user link metabox to error out on the byline profile screen.
