### PR TITLE
Bump version to 0.2.7

### DIFF
--- a/byline-manager.php
+++ b/byline-manager.php
@@ -7,10 +7,10 @@
  * Author URI:      https://alley.com
  * Text Domain:     byline-manager
  * Domain Path:     /languages
- * Version:         0.2.6
+ * Version:         0.2.7
  * Requires WP:     5.9
  * Requires PHP:    8.0
- * Tested up to:    6.3
+ * Tested up to:    6.4
  *
  * @package Byline_Manager
  */


### PR DESCRIPTION
Releases version 0.2.7 of the plugin by bumping the version. Updates tested up to as well.