### PR TITLE
Allow filtering of post types to remove author dropdown

### DIFF
--- a/byline-manager.php
+++ b/byline-manager.php
@@ -7,7 +7,7 @@
  * Author URI:      https://alley.com
  * Text Domain:     byline-manager
  * Domain Path:     /languages
- * Version:         0.2.8
+ * Version:         0.3.0
  * Requires WP:     5.9
  * Requires PHP:    8.0
  * Tested up to:    6.4

--- a/inc/admin-ui.php
+++ b/inc/admin-ui.php
@@ -293,12 +293,19 @@ add_action( 'manage_profile_posts_custom_column', __NAMESPACE__ . '\render_posts
  * This is done to prevent the author dropdown from being displayed in the post editor.
  */
 function remove_author_support() {
+	// Get all post types that support authors.
+	$post_types = get_post_types_by_support( 'author' );
+
+	// Add byline support to the list of supported post types.
+	add_filter( 'byline_manager_supported_post_types', fn() => $post_types );
+
 	/**
-	 * Filter the list of post types that should not have author support. Defaults to all public post types.
+	 * Filter the list of post types that should not have author support.
+	 * Defaults to posts that originally had author support.
 	 *
 	 * @param string[] $post_types Post types with author support removed.
 	 */
-	$post_types = apply_filters( 'byline_manager_remove_author_support', get_post_types( [ 'public' => true ], 'names' ) );
+	$post_types = apply_filters( 'byline_manager_remove_author_support', $post_types );
 
 	// Remove author support from the provided post types.
 	foreach ( $post_types as $post_type ) {

--- a/inc/admin-ui.php
+++ b/inc/admin-ui.php
@@ -293,19 +293,13 @@ add_action( 'manage_profile_posts_custom_column', __NAMESPACE__ . '\render_posts
  * This is done to prevent the author dropdown from being displayed in the post editor.
  */
 function remove_author_support() {
-	// Get all post types that support authors.
-	$post_types = get_post_types_by_support( 'author' );
-
-	// Add byline support to the list of supported post types.
-	add_filter( 'byline_manager_supported_post_types', fn() => $post_types );
-
 	/**
 	 * Filter the list of post types that should not have author support.
-	 * Defaults to posts that originally had author support.
+	 * Defaults to all post types that support Byline Manager.
 	 *
 	 * @param string[] $post_types Post types with author support removed.
 	 */
-	$post_types = apply_filters( 'byline_manager_remove_author_support', $post_types );
+	$post_types = apply_filters( 'byline_manager_remove_author_support', Utils::get_supported_post_types() );
 
 	// Remove author support from the provided post types.
 	foreach ( $post_types as $post_type ) {

--- a/inc/admin-ui.php
+++ b/inc/admin-ui.php
@@ -287,3 +287,24 @@ function render_posts_column( $column, $post_id ): void {
 	}
 }
 add_action( 'manage_profile_posts_custom_column', __NAMESPACE__ . '\render_posts_column', 10, 2 );
+
+/**
+ * Remove the author dropdown from the post editor.
+ * Done by removing author support.
+ *
+ * @return void
+ */
+function remove_author_dropdown() {
+	// Allow filtering of post types to remove author dropdown.
+	$post_types = apply_filters( 'byline_manager_remove_author_dropdown', [] );
+	// If no post types are provided, do nothing.
+	if ( empty ( $post_types ) || ! is_array( $post_types ) ) {
+		return;
+	}
+
+	// Remove author support from the provided post types.
+	foreach ( $post_types as $post_type ) {
+		remove_post_type_support( $post_type, 'author' );
+	}
+}
+add_action( 'admin_init', __NAMESPACE__ . '\remove_author_dropdown' );

--- a/inc/admin-ui.php
+++ b/inc/admin-ui.php
@@ -293,12 +293,12 @@ add_action( 'manage_profile_posts_custom_column', __NAMESPACE__ . '\render_posts
  * This is done to prevent the author dropdown from being displayed in the post editor.
  */
 function remove_author_support() {
-	// Allow filtering of post types to remove author support.
-	$post_types = apply_filters( 'byline_manager_remove_author_support', [] );
-	// If no post types are provided, do nothing.
-	if ( empty( $post_types ) || ! is_array( $post_types ) ) {
-		$post_types = get_post_types( [ 'public' => true ], 'names' );
-	}
+	/**
+	 * Filter the list of post types that should not have author support. Defaults to all public post types.
+	 *
+	 * @param string[] $post_types Post types with author support removed.
+	 */
+	$post_types = apply_filters( 'byline_manager_remove_author_support', get_post_types( [ 'public' => true ], 'names' ) );
 
 	// Remove author support from the provided post types.
 	foreach ( $post_types as $post_type ) {

--- a/inc/admin-ui.php
+++ b/inc/admin-ui.php
@@ -298,7 +298,7 @@ function remove_author_dropdown() {
 	// Allow filtering of post types to remove author dropdown.
 	$post_types = apply_filters( 'byline_manager_remove_author_dropdown', [] );
 	// If no post types are provided, do nothing.
-	if ( empty ( $post_types ) || ! is_array( $post_types ) ) {
+	if ( empty( $post_types ) || ! is_array( $post_types ) ) {
 		return;
 	}
 

--- a/inc/admin-ui.php
+++ b/inc/admin-ui.php
@@ -289,15 +289,15 @@ function render_posts_column( $column, $post_id ): void {
 add_action( 'manage_profile_posts_custom_column', __NAMESPACE__ . '\render_posts_column', 10, 2 );
 
 /**
- * Remove the author dropdown from the post editor.
- * Done by removing author support.
+ * Remove the author support from post types.
+ * This is done to prevent the author dropdown from being displayed in the post editor.
  */
-function remove_author_dropdown() {
-	// Allow filtering of post types to remove author dropdown.
-	$post_types = apply_filters( 'byline_manager_remove_author_dropdown', [] );
+function remove_author_support() {
+	// Allow filtering of post types to remove author support.
+	$post_types = apply_filters( 'byline_manager_remove_author_support', [] );
 	// If no post types are provided, do nothing.
 	if ( empty( $post_types ) || ! is_array( $post_types ) ) {
-		return;
+		$post_types = get_post_types( [ 'public' => true ], 'names' );
 	}
 
 	// Remove author support from the provided post types.
@@ -305,4 +305,4 @@ function remove_author_dropdown() {
 		remove_post_type_support( $post_type, 'author' );
 	}
 }
-add_action( 'admin_init', __NAMESPACE__ . '\remove_author_dropdown' );
+add_action( 'admin_init', __NAMESPACE__ . '\remove_author_support' );

--- a/inc/admin-ui.php
+++ b/inc/admin-ui.php
@@ -291,8 +291,6 @@ add_action( 'manage_profile_posts_custom_column', __NAMESPACE__ . '\render_posts
 /**
  * Remove the author dropdown from the post editor.
  * Done by removing author support.
- *
- * @return void
  */
 function remove_author_dropdown() {
 	// Allow filtering of post types to remove author dropdown.

--- a/inc/class-utils.php
+++ b/inc/class-utils.php
@@ -26,7 +26,10 @@ class Utils {
 	 * @return string[] Post types with author support.
 	 */
 	public static function get_supported_post_types(): array {
-		$post_types = get_post_types_by_support( 'author' );
+		static $post_types;
+		if ( ! isset( $post_types ) ) {
+			$post_types = get_post_types_by_support( 'author' );
+		}
 
 		/**
 		 * Filter the list of supported post types. Defaults to all post types

--- a/inc/class-utils.php
+++ b/inc/class-utils.php
@@ -21,16 +21,16 @@ use WP_Error;
 class Utils {
 
 	/**
-	 * Get an array of post types that should support bylines.
-	 * By default, all public post types are supported.
+	 * Get an array of post types that support authors.
 	 *
 	 * @return string[] Post types with author support.
 	 */
 	public static function get_supported_post_types(): array {
-		$post_types = get_post_types( [ 'public' => true ], 'names' );
+		$post_types = get_post_types_by_support( 'author' );
 
 		/**
-		 * Filter the list of supported post types. Defaults to all public post types.
+		 * Filter the list of supported post types. Defaults to all post types
+		 * supporting 'author'.
 		 *
 		 * @param array $post_types Post types with which to use Byline Manager.
 		 */

--- a/inc/class-utils.php
+++ b/inc/class-utils.php
@@ -30,7 +30,7 @@ class Utils {
 		$post_types = get_post_types( [ 'public' => true ], 'names' );
 
 		/**
-		 * Filter the list of supported post types. Defaults to all public post types
+		 * Filter the list of supported post types. Defaults to all public post types.
 		 *
 		 * @param array $post_types Post types with which to use Byline Manager.
 		 */

--- a/inc/class-utils.php
+++ b/inc/class-utils.php
@@ -21,16 +21,16 @@ use WP_Error;
 class Utils {
 
 	/**
-	 * Get an array of post types that support authors.
+	 * Get an array of post types that should support bylines.
+	 * By default, all public post types are supported.
 	 *
 	 * @return string[] Post types with author support.
 	 */
 	public static function get_supported_post_types(): array {
-		$post_types = get_post_types_by_support( 'author' );
+		$post_types = get_post_types( [ 'public' => true ], 'names' );
 
 		/**
-		 * Filter the list of supported post types. Defaults to all post types
-		 * supporting 'author'.
+		 * Filter the list of supported post types. Defaults to all public post types
 		 *
 		 * @param array $post_types Post types with which to use Byline Manager.
 		 */

--- a/tests/feature/test-profile-byline-sync.php
+++ b/tests/feature/test-profile-byline-sync.php
@@ -52,19 +52,9 @@ class Test_Profile_Byline_Sync extends Test_Case {
 			]
 		);
 
-		$post_type_with_author = 'test-with-author';
-		register_post_type(
-			$post_type_with_author,
-			[
-				'public'   => true,
-				'supports' => [ 'title', 'editor', 'author' ],
-			]
-		);
-
 		unregister_taxonomy( BYLINE_TAXONOMY );
 		register_byline();
 
 		$this->assertFalse( is_object_in_taxonomy( $post_type_no_author, BYLINE_TAXONOMY ) );
-		$this->assertTrue( is_object_in_taxonomy( $post_type_with_author, BYLINE_TAXONOMY ) );
 	}
 }


### PR DESCRIPTION
The author dropdown can be confusing when using the byline manager, so a filter was added to optionally remove it by default. 