### PR TITLE
Update browserslist

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "webpack-stats-plugin": "^1.1.3"
   },
   "browserslist": [
-    "> 0.5% in US",
-    "ie > 10"
+    "defaults",
+    "not IE 11"
   ]
 }


### PR DESCRIPTION
This resolves an incompatibility with WordPress 6.6.

refs WordPress/gutenberg#62923