### PR TITLE
Declare term_id as a property of the profile object

### DIFF
--- a/inc/models/class-profile.php
+++ b/inc/models/class-profile.php
@@ -36,7 +36,7 @@ class Profile {
 	/**
 	 * Profile Term ID.
 	 *
-	 * @var WP_Term
+	 * @var int
 	 */
 	public $term_id;
 

--- a/inc/models/class-profile.php
+++ b/inc/models/class-profile.php
@@ -34,6 +34,13 @@ class Profile {
 	public $post;
 
 	/**
+	 * Profile Term ID.
+	 *
+	 * @var WP_Term
+	 */
+	public $term_id;
+
+	/**
 	 * Create a new Profile object.
 	 *
 	 * @param array $args Arguments with which to create the new object.


### PR DESCRIPTION
Address #377 - This pull request declares the term_id property on the profile so that, when it is set, a php > 8.1 will not warn that setting an undeclared property is deprecated.