### PR TITLE
Update Block Editor tools and release 0.6.3

### DIFF
--- a/byline-manager.php
+++ b/byline-manager.php
@@ -7,7 +7,7 @@
  * Author URI:      https://alley.com
  * Text Domain:     byline-manager
  * Domain Path:     /languages
- * Version:         0.6.2
+ * Version:         0.6.3
  * Requires WP:     6.3
  * Requires PHP:    8.1
  * Tested up to:    6.8

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "name": "byline-manager",
       "hasInstallScript": true,
       "dependencies": {
-        "@alleyinteractive/block-editor-tools": "^0.12.1",
+        "@alleyinteractive/block-editor-tools": "^0.13.0",
         "@uidotdev/usehooks": "^2.4.1",
         "@wordpress/api-fetch": "^6.47.0",
         "@wordpress/components": "^25.8.14",
@@ -91,10 +91,9 @@
       }
     },
     "node_modules/@alleyinteractive/block-editor-tools": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/@alleyinteractive/block-editor-tools/-/block-editor-tools-0.12.1.tgz",
-      "integrity": "sha512-XiAVVSzK1iiXHyXRqMT9b57YK7r9NL6I13WsJi03QfNZsoYU8/Wycba3rYSyNqNonOcLpkvB2m/BeSVK8TnVJA==",
-      "license": "GPL-2.0-or-later",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@alleyinteractive/block-editor-tools/-/block-editor-tools-0.13.0.tgz",
+      "integrity": "sha512-cEzru+jVOsi7Dy/K8o4zLlZyLE3VsNrhKoMtBo2NjYqR+tnzYWs79LoGYotIVtWoaB4Dq3Jy0K8jAQJXy0YaVw==",
       "engines": {
         "node": ">=16.0.0 <23.0.0",
         "npm": ">=8.0.0"

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "webpack-dev-server": "^5.2.0"
   },
   "dependencies": {
-    "@alleyinteractive/block-editor-tools": "^0.12.1",
+    "@alleyinteractive/block-editor-tools": "^0.13.0",
     "@uidotdev/usehooks": "^2.4.1",
     "@wordpress/api-fetch": "^6.47.0",
     "@wordpress/components": "^25.8.14",


### PR DESCRIPTION
* Updates Block Editor Tools to 0.13.0, which includes security updates (0.13.0) and styled components for the post picker items (0.12.2), isolating them from other styling on the page.
* Increments plugin version to 0.6.3.