### PR TITLE
Add s parameter back as its required for relevance sorting

### DIFF
--- a/inc/rest-api.php
+++ b/inc/rest-api.php
@@ -67,6 +67,7 @@ function rest_profile_search( WP_REST_Request $request ): WP_REST_Response {
 		[
 			'post_type'        => PROFILE_POST_TYPE,
 			'numberposts'      => 10,
+			's'                => $request->get_param( 's' ),
 			'suppress_filters' => false,
 			'orderby'          => 'relevance',
 			'include'          => [ $request->get_param( 'id' ) ],


### PR DESCRIPTION
The `s` parameter is required for `orderby=relevance` to work. It was removed when we transitioned to a post picker for the Gutenberg work, however this path is still required for the Classic Editor, which a few clients are still using.