### PR TITLE
Prevent register_post_type() race conditions

### DIFF
--- a/inc/admin-ui.php
+++ b/inc/admin-ui.php
@@ -331,7 +331,7 @@ function maybe_modify_post_edit_columns() {
 		}
 	}
 }
-add_action( 'init', __NAMESPACE__ . '\maybe_modify_post_edit_columns' );
+add_action( 'wp_loaded', __NAMESPACE__ . '\maybe_modify_post_edit_columns' );
 
 /**
  * Add a 'byline' column in the Posts list table, and rebrand the 'author' column.

--- a/inc/class-utils.php
+++ b/inc/class-utils.php
@@ -27,7 +27,7 @@ class Utils {
 	 */
 	public static function get_supported_post_types(): array {
 		static $post_types;
-		if ( ! isset( $post_types ) ) {
+		if ( ! isset( $post_types ) || ! did_action( 'wp_loaded' ) ) {
 			$post_types = get_post_types_by_support( 'author' );
 		}
 


### PR DESCRIPTION
Resolves #524

See [this comment](https://github.com/alleyinteractive/byline-manager/issues/524#issuecomment-3408080715) for a note about an alternate solution:

> Thinking aloud, I wonder if a more perfect solution might be to...
> 1. _Replace_ `'author'` support with `'bylines'` support at some point in time, e.g. once the plugin is loaded, for any post types that have so far been registered.
> 2. Hook into `registered_post_type` and replace `'author'` support with `'bylines'` support for any future-registered post types.
> 3. Change `Utils::get_supported_post_types()` to query for post types with `'bylines'` support, and do not store the value in a static variable (fwiw, static variables in functions and methods can be a real headache when writing automated tests).

This PR is a quick fix, so maybe it's worth merging now and spinning off a followup issue to implement that idea? Or maybe we should do that now. Open to feedback!